### PR TITLE
Update dependencies for DHT22 sensor //Simon & Zulius

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -1,11 +1,11 @@
 import RPi.GPIO as GPIO
-import Adafruit_DHT # Importing a library used for the DHT22 which is the same as our AM2302 
+import adafruit_dht # Importing a library used for the DHT22 which is the same as our AM2302 
 #import botbook_mcp3002 as mcp # For MQ-2 smoke sensor
 
 LED_PIN = 21
 AM2302_PIN = 2
 PIR_PIN = 8
-DHT_SENSOR = Adafruit_DHT.DHT22
+DHT_SENSOR = adafruit_dht.DHT22(AM2302_PIN)
 
 GPIO.setwarnings(False)
 
@@ -25,7 +25,12 @@ def read_sensor_temperature():
     """
     temperature = 0
     
-    temperature = Adafruit_DHT.read_retry(DHT_SENSOR, AM2302_PIN)[1]
+    try:
+        temperature = DHT_SENSOR.temperature
+    except:
+        temperature = -1
+    if temperature == None:
+        temperature = -1
     
     return temperature
 
@@ -34,8 +39,13 @@ def read_sensor_humidity():
     Returns the humidity as relative humidity
     """
     humidity = 0
-    
-    humidity = Adafruit_DHT.read_retry(DHT_SENSOR, AM2302_PIN)[0]
+
+    try:
+        humidity = DHT_SENSOR.humidity
+    except:
+        humidity = -1
+    if humidity == None:
+        humidity = -1
     
     return humidity
 

--- a/install_workshop_dependencies.sh
+++ b/install_workshop_dependencies.sh
@@ -6,7 +6,8 @@ sudo apt install python3
 sudo apt-get install python3-dev python3-pip
 sudo python3 -m pip install --upgrade pip setuptools wheel
 sudo pip3 install --install-option="--force-pi" Adafruit_DHT
-sudo pip3 install Adafruit_Python_DHT
+sudo pip3 install adafruit-circuitpython-lis3dh
+sudo pip3 install adafruit-circuitpython-dht
 python3 -m pip install -U --user pip gpiod
 sudo apt install libgpiod2
 sudo apt autoremove


### PR DESCRIPTION
The old [adafruit package](https://github.com/adafruit/Adafruit_Python_DHT) has been deprecated and recommends replacing it with circuit package.
I found a special DHT package that works specifically for the humidity and temperature sensor:
The sensor package [link](https://github.com/adafruit/Adafruit_CircuitPython_DHT)
Which is depended on this package [link](https://github.com/adafruit/Adafruit_CircuitPython_Bundle)
They are both added in _install_workshop_dependencies.sh_ for future installments