### PR TITLE
update readability for dependency script

### DIFF
--- a/install_workshop_dependencies.sh
+++ b/install_workshop_dependencies.sh
@@ -1,16 +1,22 @@
 #!/bin/sh
-sudo apt install git
-sudo apt full-upgrade
-sudo apt install code
-sudo apt install python3
-sudo apt-get install python3-dev python3-pip
-sudo python3 -m pip install --upgrade pip setuptools wheel
-sudo pip3 install --install-option="--force-pi" Adafruit_DHT
-sudo pip3 install adafruit-circuitpython-lis3dh
-sudo pip3 install adafruit-circuitpython-dht
-python3 -m pip install -U --user pip gpiod
-sudo apt install libgpiod2
-sudo apt autoremove
+apt-get update && apt-get install -y \
+    git \
+    code \
+    python3 \
+    python3-dev \
+    python3-pip \
+    libgpiod2
+
+apt full-upgrade
+apt autoremove
+
+pip3 install --upgrade --user pip \
+    setuptools \
+    wheel \
+    gpiod \
+    adafruit-circuitpython-lis3dh \
+    adafruit-circuitpython-dht
+
 echo "-----------------------------------------------"
 echo "----------- Everything is set setup -----------"
 echo "-----------------------------------------------"


### PR DESCRIPTION
Before accepting the pull request, please check if the script actually works on the raspberry pi, I tried in on my linux machine and it didn't complain at least.
I removed the `sudo` in the shell script as you should use `sudo ./install_workshop_dependencies`