### PR TITLE
Dependency updates

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -1,8 +1,9 @@
 import RPi.GPIO as GPIO
 import adafruit_dht  # DHT22 library can be used for AM2302
+from microcontroller import Pin
 
 LED_PIN = 21
-AM2302_PIN = 2
+AM2302_PIN = Pin(2)
 PIR_MOTION_PIN = 8
 DHT_SENSOR = adafruit_dht.DHT22(AM2302_PIN)
 

--- a/install_workshop_dependencies.sh
+++ b/install_workshop_dependencies.sh
@@ -15,7 +15,7 @@ pip3 install --upgrade --user pip \
     wheel \
     gpiod \
     adafruit-circuitpython-lis3dh \
-    adafruit-circuitpython-dht
+    adafruit-circuitpython-dht --break-system-packages
 
 echo "-----------------------------------------------"
 echo "----------- Everything is set setup -----------"


### PR DESCRIPTION
Due to ever changing dependencies, they need to be updated every so often. This pull request aims to do that for the workshop the 7th of march, 2024. 

There were two problems encountered. 

1. The pip packages didn't want to be installed, due to it being a externally managed environment. 
2. The Adafruit_dht library didn't work out of the box with the given code.

Number 1 was solved by using the '--break-system-packages' on the pip install. Another solution could be virtual envs, but does require a bit more "configuring". 

For number 2. the library no longer expects a int and wants a class Pin. Which could be imported from the microprocessor library.
